### PR TITLE
fix(docs/workflow): adicionar fi faltante no step Update SPEC versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -97,6 +97,7 @@ jobs:
             fi
           else
             echo "docs/spec directory does not exist, skipping"
+          fi
 
       - name: Generate version index
         run: |


### PR DESCRIPTION
## Summary
- Adiciona `fi` faltante para fechar o bloco `if/else` no step "Update SPEC versions"
- Corrige erro de sintaxe bash: `syntax error: unexpected end of file`

## Contexto
Resolve #7

O workflow `.github/workflows/docs.yml` estava falhando com erro de sintaxe bash porque o bloco `if/else` no step "Update SPEC versions" não estava fechado corretamente.

## Test plan
- [ ] Workflow docs.yml executa sem erro de sintaxe
- [ ] Step "Update SPEC versions" completa com sucesso

> "A precisão nos detalhes cria a robustez do todo" – made by Sky 🛠️