### PR TITLE
feat(ci): habilitar modo detalhado no changelog do release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           echo "🔍 Generating changelog for ${NEW_VERSION} (from ${LATEST_TAG:-initial})..."
 
           # Generate changelog using Sky Python script
-          python -m runtime.changelog "${NEW_VERSION}" "${LATEST_TAG}" --from-gh --apply
+          python -m runtime.changelog "${NEW_VERSION}" "${LATEST_TAG}" --from-gh --detailed --apply
 
           # Configure git
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Sumário

Habilita o modo detalhado (`--detailed`) no workflow de release para que releases futuras incluam todos os commits internos das PRs via API GitHub.

## Mudança

Adiciona flag `--detailed` ao comando do changelog generator:

```yaml
python -m runtime.changelog "${NEW_VERSION}" "${LATEST_TAG}" --from-gh --detailed --apply
```

## Benefícios

Com o modo detalhado, cada release mostrará:
- **Todos os commits internos** de cada PR, não apenas o commit de merge
- **Agrupamento por PR** com cabeçalhos clicáveis `[**#NN**]`
- **Histórico completo** de desenvolvimento, mesmo com squash merge
- **Links ricos** para commits, PRs e autores

## Exemplo

Sem `--detailed` (simples):
```markdown
### ✨ Novidades
* [`7534cd9`](...) webhooks: sincronização ([#49](...))
```

Com `--detailed`:
```markdown
### ✨ Novidades
[**#49**](...) - sincronização de labels e correção de handlers
* [`93b8517`](...) webhooks: sincronização de labels ([#49](...))
* [`7534cd9`](...) webhooks: sincronização labels ([#49](...))
* [`3daab9f`](...) runtime: Demo Engine ([#49](...))
* [`93468f5`](...) ci: gerador changelog Python
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)