### PR TITLE
fix: Webhooks being processed multiple times

### DIFF
--- a/src/infra/webhooks/adapters/file_based_job_queue.py
+++ b/src/infra/webhooks/adapters/file_based_job_queue.py
@@ -343,7 +343,7 @@ class FileBasedJobQueue(JobQueuePort):
                 try:
                     job_data = json.loads(job_file.read_text(encoding="utf-8"))
                     event_data = job_data.get("event", {})
-                    if event_data.get("event_id") == delivery_id:
+                    if event_data.get("delivery_id") == delivery_id:
                         return True
                 except Exception:
                     continue
@@ -421,6 +421,7 @@ class FileBasedJobQueue(JobQueuePort):
                 "payload": job.event.payload,
                 "received_at": job.event.received_at.isoformat(),
                 "signature": job.event.signature,
+                "delivery_id": job.event.delivery_id,
             },
             "status": job.status.value,
             "worktree_path": job.worktree_path,
@@ -448,6 +449,7 @@ class FileBasedJobQueue(JobQueuePort):
             payload=event_data["payload"],
             received_at=datetime.fromisoformat(event_data["received_at"]),
             signature=event_data.get("signature"),
+            delivery_id=event_data.get("delivery_id"),
         )
 
         return WebhookJob(


### PR DESCRIPTION
## Summary
Fixed bug where GitHub webhooks were being processed multiple times, causing duplicate jobs to be created.

## Root Cause
The `FileBasedJobQueue` was not persisting the `delivery_id` field when serializing jobs to JSON. This caused the duplicate check in `WebhookProcessor.process_github_issue()` (lines 74-76) to always return `False`, even for duplicate webhooks.

## Changes
- **`src/infra/webhooks/adapters/file_based_job_queue.py`**:
  - Added `delivery_id` to event serialization in `_job_to_json()` (line 424)
  - Added `delivery_id` deserialization in `_job_from_dict()` (line 452)
  - Fixed `exists_by_delivery()` to check `delivery_id` instead of `event_id` (line 346)

## Test Plan
- [x] All existing deduplication tests pass (21/21)
- [x] Manual verification: delivery_id is now persisted in JSON
- [x] Manual verification: exists_by_delivery() correctly identifies duplicates
- [x] WebhookProcessor duplicate check now works as intended

## Expected Behavior
When the same webhook (with identical `delivery_id`) is received multiple times from GitHub, the second and subsequent requests will be ignored, preventing duplicate job creation.

> "Simplicidade é o último grau de sofisticação" – made by Sky 🚀