### PR TITLE
fix(release): adicionar __init__.py ao runtime

### DIFF
--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -1,0 +1,11 @@
+"""
+Runtime module for Skybridge.
+
+Contains scripts and utilities for runtime operations including:
+- changelog.py: Automatic CHANGELOG.md generation
+- demo/: Scenarios and demonstrations
+
+> "O runtime é onde a magia acontece" – made by Sky 🚀
+"""
+
+__all__ = []


### PR DESCRIPTION
## 🐛 Bug Fix

Corrige o erro `No module named runtime.changelog` no workflow de release.

## 🔧 Resumo

O workflow de release executa `python -m runtime.changelog`, mas o Python
não conseguia importar `runtime` como módulo porque faltava o `__init__.py`.

## ✅ Solução

- Adicionado `runtime/__init__.py` para tornar `runtime/` um pacote Python válido
- O módulo agora pode ser importado e executado como `python -m runtime.changelog`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)